### PR TITLE
Enhance to use paths for Conda environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 SEAMM exec
 ==============================
 [//]: # (Badges)
-[![GitHub Actions Build Status](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/seamm_exec/workflows/CI/badge.svg)](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/seamm_exec/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/SEAMM exec/branch/main/graph/badge.svg)](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/SEAMM exec/branch/main)
+[![GitHub Actions Build Status](https://github.com/molssi-seamm/seamm_exec/workflows/CI/badge.svg)](https://github.com/molssi-seamm/seamm_exec/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/molssi-seamm/SEAMM exec/branch/main/graph/badge.svg)](https://codecov.io/gh/molssi-seamm/SEAMM exec/branch/main)
 
 
 Classes to execute background codes for SEAMM

--- a/seamm_exec/local.py
+++ b/seamm_exec/local.py
@@ -5,6 +5,7 @@ runs, an executable locally."""
 
 import logging
 import os
+from pathlib import Path
 import pprint
 import subprocess
 
@@ -68,7 +69,15 @@ class Local(Base):
         # Sift through the way we can find the executables.
         # 1. Conda
         if "conda-environment" in config and config["conda-environment"] != "":
-            command = "conda run -n {conda-environment} " + command
+            # May be the name of the environment or the path to the environment
+            environment = config["conda-environment"]
+            if environment[0] == "~":
+                environment = str(Path(environment).expanduser())
+                command = f"conda run -p '{environment}' " + command
+            elif Path(environment).is_absolute():
+                command = f"conda run -p '{environment}' " + command
+            else:
+                command = "conda run -n {conda-environment} " + command
 
         # 2. modules
         modules = ""


### PR DESCRIPTION
## Description
Allow Conda environments to be specified as paths rather than by name.
The path must be relative to the home directory or an absolute path.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Allows using Conda environments with other roots than the main root.
  - [x] Also fixed the paths of the badges in the README

## Status
- [x] Tested and ready to go