### PR TITLE
Adding platform to Docker runs

### DIFF
--- a/seamm_exec/docker.py
+++ b/seamm_exec/docker.py
@@ -101,6 +101,9 @@ class Docker(Base):
         # Replace any variables in the container name
         container = config["container"].format(**config, **ce)
 
+        # See if there is a required platform
+        platform = config.get("platform", None)
+
         if len(cmd) > 0:
             # Replace any variables in the command with values from the config file
             # and computational environment. Maybe nested.
@@ -118,6 +121,7 @@ class Docker(Base):
                     command={command},
                     environment={env},
                     image={container},
+                    platform={platform},
                     remove=True,
                     stderr=True,
                     stdout=True,
@@ -131,6 +135,7 @@ class Docker(Base):
                 command=command,
                 environment=env,
                 image=container,
+                platform=platform,
                 remove=True,
                 stderr=True,
                 stdout=True,
@@ -143,6 +148,7 @@ class Docker(Base):
                 result = client.containers.run(
                     environment={env},
                     image={container},
+                    platform={platform},
                     remove=True,
                     stderr=True,
                     stdout=True,
@@ -155,6 +161,7 @@ class Docker(Base):
             result = client.containers.run(
                 environment=env,
                 image=container,
+                platform=platform,
                 remove=True,
                 stderr=True,
                 stdout=True,

--- a/seamm_exec/local.py
+++ b/seamm_exec/local.py
@@ -138,6 +138,9 @@ class Local(Base):
             # Replace any variables in the container name
             container = config["container"].format(**config, **ce)
 
+            # See if there is a required platform
+            platform = config.get("platform", None)
+
             if len(cmd) > 0:
                 # Replace any variables in the command with values from the config file
                 # and computational environment. Maybe nested.
@@ -155,6 +158,7 @@ class Local(Base):
                         command={command},
                         environment={env},
                         image={container},
+                        platform={platform},
                         remove=True,
                         stderr=True,
                         stdout=True,
@@ -168,6 +172,7 @@ class Local(Base):
                     command=command,
                     environment=env,
                     image=container,
+                    platform=platform,
                     remove=True,
                     stderr=True,
                     stdout=True,
@@ -180,6 +185,7 @@ class Local(Base):
                     result = client.containers.run(
                         environment={env},
                         image={container},
+                        platform={platform},
                         remove=True,
                         stderr=True,
                         stdout=True,
@@ -192,6 +198,7 @@ class Local(Base):
                 result = client.containers.run(
                     environment=env,
                     image=container,
+                    platform=platform,
                     remove=True,
                     stderr=True,
                     stdout=True,


### PR DESCRIPTION
## Description
Adding support for the platform when running Docker images. This allows running e.g. linux/amd64 images on Mac Mn ARM machines instead of the native linux/arm64 images, allowing support of codes without arm64 versions

## Status
- [X] Ready to go