### PR TITLE
Handling running a flowchart in Docker, the JobServer in Docker, and running without Docker.

### DIFF
--- a/seamm_exec/docker.py
+++ b/seamm_exec/docker.py
@@ -98,12 +98,18 @@ class Docker(Base):
                 if mount["Destination"] == "/home":
                     path = Path(mount["Source"]).joinpath(*directory.parts[2:])
                     break
+                elif mount["Destination"] == "/root/SEAMM":
+                    path = Path(mount["Source"]).joinpath(*directory.parts[3:])
+                    break
             else:
                 raise RuntimeError(
-                    f"/home was not in the mounts for the container!\n{mounts=}"
+                    "Neither /home or /root/SEAMM were in the mounts for the container!"
+                    "\n{mounts=}"
                 )
         else:
+            # Not in a Docker container, so use the path as is
             path = Path(directory)
+
         self.logger.debug(f"path = {path}\n")
 
         self.logger.debug(pprint.pformat(config, compact=True))


### PR DESCRIPTION
## Description
Adding support for all three ways of running currently supported:

1. Within a Conda environment (the original approach)
2. Running a flowchart in a Docker container, with the working directory mounted as /home
3. Running from the JobServer within a Docker container, with ~/SEAMM mounted as /root/SEAMM in the container

## Status
- [x] Ready to go. However, cannot fully test until this is merged and containers are created.