### PR TITLE
Fixed issues with arguments including the host paths, not the mounted paths

### DIFF
--- a/seamm_exec/local.py
+++ b/seamm_exec/local.py
@@ -160,6 +160,10 @@ class Local(Base):
                         break
                     tmp = command
 
+                # If running using Docker, we have to munge any paths in the command
+                prefix = str(directory)
+                command = command.replace(prefix, "/home")
+
                 self.logger.debug(
                     f"""
                     result = client.containers.run(


### PR DESCRIPTION
## Description
Fixes issue using Docker to run a command that has file path arguments. They need to be transformed from the host file system paths to the docker image mounted paths.

## Status
- [x] Ready to go